### PR TITLE
Autogenerate itowns example pages

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
                 <a href="">Go to</a>
                 <ul>
                     <li><a href="/itowns/API_Doc">Documentation</a></li>
-                    <li><a href="/itowns/examples">Examples and demos</a></li>
+                    <li><a href="/examples.html">Examples and demos</a></li>
                     <li><a href="https://github.com/itowns/itowns">Github repository</a></li>
                     <li><a href="https://github.com/iTowns/iTowns2-sample-data">Sample data</a></li>
                 </ul>

--- a/examples.html
+++ b/examples.html
@@ -1,0 +1,59 @@
+---
+---
+<style type="text/css">
+    iframe {
+        width: 300px;
+        height: 200px;
+        border: none;
+    }
+    .exampleContainer {
+        width: 350px;
+        display: inline-block;
+    }
+</style>
+<!-- Main -->
+<article id="main">
+
+    <section id="data_types" class="wrapper style3 container special-alt">
+        <h1>Itowns Examples</h1>
+        <p>
+        (click on title to open fullscreen)
+        </p>
+        {% assign screenshotsDir = "/itowns/examples/screenshots/" %}
+        {% comment %}
+            Putting "for" and "if" starting and ending tags in one
+            line, because liquid keeps the newline. So we added ~10 newlines for
+            each static files in our site, meaning this page would grow each
+            time we add an asset somewhere... (at the time of writing,
+            generated html contained more than 500 blank lines because of this).
+        {% endcomment %}
+        {% for file in site.static_files %}{% assign prefix = file.path | slice: 0, 29 %}{% if prefix == "/itowns/examples/screenshots/" and file.extname == '.jpg' %}
+            {% assign extSize = file.path.size | minus: 4 %}
+            {% assign example = file.path | slice: 0, extSize | remove_first: "/itowns/examples/screenshots/" %}
+            {% unless example contains "/" %}
+                <div class="exampleContainer" >
+                    <h3>
+                        <a href="/itowns/examples/{{ example }}.html" target="_blank">{{ example }}</a>
+                    </h3>
+                    <img src="/itowns/examples/screenshots/{{ example }}.jpg">
+                    <iframe src="" style="display: none;"></iframe>
+                </div>
+        {% endunless %} {% endif %} {% endfor %}
+    </section>
+
+</article>
+
+<script type="text/javascript">
+    function enableOnClick(evt) {
+        this.getElementsByTagName('img')[0].style.display = 'none';
+        this.getElementsByTagName('iframe')[0].style.display = '';
+        this.getElementsByTagName('iframe')[0].src = this.getElementsByTagName('a')[0].href;
+    }
+
+    var divs = document.getElementsByClassName('exampleContainer');
+    var i;
+    for (i = 0; i < divs.length; i++) {
+        divs[i].addEventListener('click', enableOnClick.bind(divs[i]));
+    }
+</script>
+

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         </p>
         <footer>
           See <strong><a href="#video">videos</a></strong>,
-          try <strong><a href="/itowns/examples/index.html">examples</a></strong>,
+          try <strong><a href="/examples.html">examples</a></strong>,
           download <strong><a href="https://github.com/iTowns/itowns/releases/latest">latest release</a></strong>,
           read <strong><a href="/itowns/API_Doc">the doc</a></strong>
           or head directly to our <strong><a href="https://github.com/itowns/itowns">Github repository</a></strong> to get started.
@@ -62,7 +62,7 @@
 
     <section id="data_types" class="wrapper style3 container special-alt">
         <h2>Examples:</h2>
-        <a href="/itowns/examples/index.html"><img src="./images/montage.jpg"></a>
+        <a href="/examples.html"><img src="./images/montage.jpg"></a>
     </section>
 <!--
     <section id="data_types" class="wrapper style3 container special-alt">


### PR DESCRIPTION
This PR auto-generates a page containing examples from `/itowns/examples`.

**Context and Motivation**

It will be quickly cumbersome to maintain our `/itowns/examples/index.html`. 

Moreover, we want this page to integrate into our jekyll template. Therefore auto-generating it from the files in this folders might save us some pain.

