### PR TITLE
Support different site.baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,7 @@ title: iTowns
 email: sysadmin+itowns@oslandia.com
 description: > # this means to ignore newlines until "baseurl:"
     iTowns is a JS/WebGL framework for 3D geospatial data visualization
-baseurl: "" # the subpath of your site, e.g. /blog/
+baseurl: "/itowns.github.io" # the subpath of your site, e.g. /blog/
 url: "http://www.itowns-project.org" # the base hostname & protocol for your site
 twitter_username: jekyllrb
 github_username: jekyll

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,18 +10,21 @@
     <meta name="description" content="{{ site.description }}">
     <meta name="keywords" content="" />
     <!--[if lte IE 8]><script src="css/ie/html5shiv.js"></script><![endif]-->
-    <script src="/js/jquery.min.js"></script>
-    <script src="/js/jquery.dropotron.min.js"></script>
-    <script src="/js/jquery.scrolly.min.js"></script>
-    <script src="/js/jquery.scrollgress.min.js"></script>
-    <script src="/js/skel.min.js"></script>
-    <script src="/js/skel-layers.min.js"></script>
-    <script src="/js/init.js"></script>
+    <script src="{{ site.baseurl }}/js/jquery.min.js"></script>
+    <script src="{{ site.baseurl }}/js/jquery.dropotron.min.js"></script>
+    <script src="{{ site.baseurl }}/js/jquery.scrolly.min.js"></script>
+    <script src="{{ site.baseurl }}/js/jquery.scrollgress.min.js"></script>
+    <script src="{{ site.baseurl }}/js/skel.min.js"></script>
+    <script src="{{ site.baseurl }}/js/skel-layers.min.js"></script>
+    <script>
+        var baseUrl = "{{ site.baseurl }}";
+    </script>
+    <script src="{{ site.baseurl }}/js/init.js"></script>
     <noscript>
-        <link rel="stylesheet" href="/css/skel.css" />
-        <link rel="stylesheet" href="/css/style.css" />
-        <link rel="stylesheet" href="/css/style-wide.css" />
-        <link rel="stylesheet" href="/css/style-noscript.css" />
+        <link rel="stylesheet" href="{{ site.baseurl }}/css/skel.css" />
+        <link rel="stylesheet" href="{{ site.baseurl }}/css/style.css" />
+        <link rel="stylesheet" href="{{ site.baseurl }}/css/style-wide.css" />
+        <link rel="stylesheet" href="{{ site.baseurl }}/css/style-noscript.css" />
     </noscript>
     <!--[if lte IE 8]><link rel="stylesheet" href="/css/ie/v8.css" /><![endif]-->
     <!--[if lte IE 9]><link rel="stylesheet" href="/css/ie/v9.css" /><![endif]-->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,12 +2,12 @@
 
     <nav id="nav">
         <ul>
-            <li><a href="/">Welcome</a></li>
+            <li><a href="{{ site.baseurl }}/">Welcome</a></li>
             <li class="submenu">
                 <a href="">Go to</a>
                 <ul>
-                    <li><a href="/itowns/API_Doc">Documentation</a></li>
-                    <li><a href="/itowns/examples">Examples and demos</a></li>
+                    <li><a href="{{ site.baseurl }}/itowns/API_Doc">Documentation</a></li>
+                    <li><a href="{{ site.baseurl }}/itowns/examples">Examples and demos</a></li>
                     <li><a href="https://github.com/itowns/itowns">Github repository</a></li>
                     <li><a href="https://github.com/iTowns/iTowns2-sample-data">Sample data</a></li>
                 </ul>

--- a/index.html
+++ b/index.html
@@ -21,9 +21,9 @@
         </p>
         <footer>
           See <strong><a href="#video">videos</a></strong>,
-          try <strong><a href="/itowns/examples/index.html">examples</a></strong>,
+          try <strong><a href="{{ site.baseurl }}/itowns/examples/index.html">examples</a></strong>,
           download <strong><a href="https://github.com/iTowns/itowns/releases/latest">latest release</a></strong>,
-          read <strong><a href="/itowns/API_Doc">the doc</a></strong>
+          read <strong><a href="{{ site.baseurl }}/itowns/API_Doc">the doc</a></strong>
           or head directly to our <strong><a href="https://github.com/itowns/itowns">Github repository</a></strong> to get started.
           <br>
         </footer>
@@ -62,7 +62,7 @@
 
     <section id="data_types" class="wrapper style3 container special-alt">
         <h2>Examples:</h2>
-        <a href="/itowns/examples/index.html"><img src="./images/montage.jpg"></a>
+        <a href="{{ site.baseurl }}/itowns/examples/index.html"><img src="./images/montage.jpg"></a>
     </section>
 <!--
     <section id="data_types" class="wrapper style3 container special-alt">

--- a/js/init.js
+++ b/js/init.js
@@ -9,12 +9,12 @@
     skel.init({
         reset: 'full',
         breakpoints: {
-            global:		{ range: '*', href: '/css/style.css', containers: 1400, grid: { gutters: 50 } },
-            wide:		{ range: '-1680', href: '/css/style-wide.css', containers: 1200, grid: { gutters: 40 } },
-            normal:		{ range: '-1280', href: '/css/style-normal.css', containers: 960, viewport: { scalable: false } },
-            narrow:		{ range: '-980', href: '/css/style-narrow.css', containers: '95%', grid: { gutters: 30 } },
-            narrower:	{ range: '-840', href: '/css/style-narrower.css', grid: { collapse: 1 } },
-            mobile:		{ range: '-736', href: '/css/style-mobile.css', containers: '100%', grid: { gutters: 15, collapse: 2 } }
+            global:		{ range: '*', href: baseUrl + '/css/style.css', containers: 1400, grid: { gutters: 50 } },
+            wide:		{ range: '-1680', href: baseUrl + '/css/style-wide.css', containers: 1200, grid: { gutters: 40 } },
+            normal:		{ range: '-1280', href: baseUrl + '/css/style-normal.css', containers: 960, viewport: { scalable: false } },
+            narrow:		{ range: '-980', href: baseUrl + '/css/style-narrow.css', containers: '95%', grid: { gutters: 30 } },
+            narrower:	{ range: '-840', href: baseUrl + '/css/style-narrower.css', grid: { collapse: 1 } },
+            mobile:		{ range: '-736', href: baseUrl + '/css/style-mobile.css', containers: '100%', grid: { gutters: 15, collapse: 2 } }
         },
         plugins: {
             layers: {


### PR DESCRIPTION
When forking this repo and activating gh pages, the base url is <username>.github.io/itowns.github.io and all the links are broken. This commit correctly uses site.baseurl to allow live testing of this repo.

@iTowns/reviewers please r? (and check I didn't forget any links :-) )