### PR TITLE
Chore: remove API_Doc url in profit of docs

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
             <li class="submenu">
                 <a href="">Go to</a>
                 <ul>
-                    <li><a href="{{ site.baseurl }}/itowns/API_Doc">Documentation</a></li>
+                    <li><a href="{{ site.baseurl }}/itowns/docs">Documentation</a></li>
                     <li><a href="{{ site.baseurl }}/itowns/examples">Examples and demos</a></li>
                     <li><a href="https://github.com/itowns/itowns">Github repository</a></li>
                     <li><a href="https://github.com/iTowns/iTowns2-sample-data">Sample data</a></li>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
           See <strong><a href="#video">videos</a></strong>,
           try <strong><a href="{{ site.baseurl }}/itowns/examples/index.html">examples</a></strong>,
           download <strong><a href="https://github.com/iTowns/itowns/releases/latest">latest release</a></strong>,
-          read <strong><a href="{{ site.baseurl }}/itowns/API_Doc">the doc</a></strong>
+          read <strong><a href="{{ site.baseurl }}/itowns/docs">the doc</a></strong>
           or head directly to our <strong><a href="https://github.com/itowns/itowns">Github repository</a></strong> to get started.
           <br>
         </footer>


### PR DESCRIPTION
The path has changed in the last commit 